### PR TITLE
Use deduped vec for hostlist results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ description = "Parses hostlist expressions into a Vec of Strings"
 repository = "https://github.com/whamcloud/hostlist-parser"
 keywords = ["hostlist", "pdsh", "hpc", "cluster"]
 license = "MIT"
-version = "0.1.3"
-authors = ["IML Team <iml@whamcloud.com>"]
-edition = "2018"
+version = "0.1.4"
+authors = ["EMF Team <emf@whamcloud.com>"]
+edition = "2021"
 
 [dependencies]
-combine = "4.1.0"
-itertools = "0.9"
+combine = "4.6"
+itertools = "0.10"
 
 [dev-dependencies]
-insta = "0.16"
+insta = "1.12"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 whamCloud
+Copyright (c) 2022 DDN
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # hostlist-parser
 
-![Crates.io](https://img.shields.io/crates/v/hostlist-parser) ![docs.rs](https://docs.rs/hostlist-parser/badge.svg?version=0.1.3)
+![Crates.io](https://img.shields.io/crates/v/hostlist-parser) ![docs.rs](https://docs.rs/hostlist-parser/badge.svg?version=0.1.4)
 
-Parses hostlist expressions into a BtreeSet of Strings
+Parses hostlist expressions into a deduped `Vec` of Strings
 
 This library implements hostlist parsing. It takes a hostlist expression and produces a Result of unique hostnames, or a parse error that can be introspected to see issues.
 
 The fn to parse a hostlist is:
 
 ```rust
-parse(input: &str,) -> Result<BTreeSet<String>, combine::stream::easy::Errors<char, &str, usize>>
+parse(input: &str,) -> Result<Vec<String>, combine::stream::easy::Errors<char, &str, usize>>
 ```
 
 This parser can compile to native code and also with the `wasm32-unknown-unknown` target.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use combine::{
     stream::{Stream, StreamErrorFor},
     token, Parser,
 };
-use itertools::Itertools;
+use itertools::Itertools as _;
 
 fn comma<I>() -> impl Parser<I, Output = char>
 where

--- a/src/snapshots/hostlist_parser__tests__Combined Ranges.snap
+++ b/src/snapshots/hostlist_parser__tests__Combined Ranges.snap
@@ -1,19 +1,21 @@
 ---
 source: src/lib.rs
+assertion_line: 434
 expression: "parse(\"hostname[2,6,7].iml.com,hostname[10,11-12,2-3,5].iml.com, hostname[15-17].iml.com\")"
+
 ---
 Ok(
-    {
+    [
+        "hostname2.iml.com",
+        "hostname6.iml.com",
+        "hostname7.iml.com",
         "hostname10.iml.com",
         "hostname11.iml.com",
         "hostname12.iml.com",
+        "hostname3.iml.com",
+        "hostname5.iml.com",
         "hostname15.iml.com",
         "hostname16.iml.com",
         "hostname17.iml.com",
-        "hostname2.iml.com",
-        "hostname3.iml.com",
-        "hostname5.iml.com",
-        "hostname6.iml.com",
-        "hostname7.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Duplicate without using a range.snap
+++ b/src/snapshots/hostlist_parser__tests__Duplicate without using a range.snap
@@ -1,9 +1,11 @@
 ---
 source: src/lib.rs
+assertion_line: 409
 expression: "parse(\"hostname4.iml.com,hostname4.iml.com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname4.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Empty expression.snap
+++ b/src/snapshots/hostlist_parser__tests__Empty expression.snap
@@ -1,6 +1,8 @@
 ---
 source: src/lib.rs
+assertion_line: 446
 expression: "parse(\"\")"
+
 ---
 Err(
     Errors {
@@ -9,6 +11,11 @@ Err(
             Unexpected(
                 Static(
                     "no host found",
+                ),
+            ),
+            Unexpected(
+                Static(
+                    "end of input",
                 ),
             ),
         ],

--- a/src/snapshots/hostlist_parser__tests__Multiple ranges per hostname in which the difference is 1 two formats.snap
+++ b/src/snapshots/hostlist_parser__tests__Multiple ranges per hostname in which the difference is 1 two formats.snap
@@ -1,17 +1,19 @@
 ---
 source: src/lib.rs
+assertion_line: 389
 expression: "parse(\"hostname[1,2-3].iml[2,3].com,hostname[1,2,3].iml[2,4].com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname1.iml2.com",
         "hostname1.iml3.com",
-        "hostname1.iml4.com",
         "hostname2.iml2.com",
         "hostname2.iml3.com",
-        "hostname2.iml4.com",
         "hostname3.iml2.com",
         "hostname3.iml3.com",
+        "hostname1.iml4.com",
+        "hostname2.iml4.com",
         "hostname3.iml4.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Multiple ranges per hostname in which the difference is 1.snap
+++ b/src/snapshots/hostlist_parser__tests__Multiple ranges per hostname in which the difference is 1.snap
@@ -1,9 +1,11 @@
 ---
 source: src/lib.rs
+assertion_line: 387
 expression: "parse(\"hostname[1,2-3].iml[2,3].com,hostname[3,4,5].iml[2,3].com,hostname[5-6,7].iml[2,3].com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname1.iml2.com",
         "hostname1.iml3.com",
         "hostname2.iml2.com",
@@ -18,5 +20,5 @@ Ok(
         "hostname6.iml3.com",
         "hostname7.iml2.com",
         "hostname7.iml3.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Multiple ranges per hostname in which the difference is gt 1.snap
+++ b/src/snapshots/hostlist_parser__tests__Multiple ranges per hostname in which the difference is gt 1.snap
@@ -1,9 +1,11 @@
 ---
 source: src/lib.rs
+assertion_line: 387
 expression: "parse(\"hostname[1,2-3].iml[2,3].com,hostname[4,5].iml[3,4].com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname1.iml2.com",
         "hostname1.iml3.com",
         "hostname2.iml2.com",
@@ -14,5 +16,5 @@ Ok(
         "hostname4.iml4.com",
         "hostname5.iml3.com",
         "hostname5.iml4.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Overlapping ranges.snap
+++ b/src/snapshots/hostlist_parser__tests__Overlapping ranges.snap
@@ -1,9 +1,11 @@
 ---
 source: src/lib.rs
+assertion_line: 404
 expression: "parse(\"hostname[1,2-3].iml[2,3].com,hostname[3,4,5].iml[3,4].com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname1.iml2.com",
         "hostname1.iml3.com",
         "hostname2.iml2.com",
@@ -15,5 +17,5 @@ Ok(
         "hostname4.iml4.com",
         "hostname5.iml3.com",
         "hostname5.iml4.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Padding with a single and double digit number.snap
+++ b/src/snapshots/hostlist_parser__tests__Padding with a single and double digit number.snap
@@ -1,13 +1,15 @@
 ---
 source: src/lib.rs
+assertion_line: 434
 expression: "parse(\"hostname[06-10]\")"
+
 ---
 Ok(
-    {
+    [
         "hostname06",
         "hostname07",
         "hostname08",
         "hostname09",
         "hostname10",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Single item with prefix range starting at 0.snap
+++ b/src/snapshots/hostlist_parser__tests__Single item with prefix range starting at 0.snap
@@ -1,11 +1,13 @@
 ---
 source: src/lib.rs
+assertion_line: 422
 expression: "parse(\"test[000-002].localdomain\")"
+
 ---
 Ok(
-    {
+    [
         "test000.localdomain",
         "test001.localdomain",
         "test002.localdomain",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Single item with single range and additional characters after range.snap
+++ b/src/snapshots/hostlist_parser__tests__Single item with single range and additional characters after range.snap
@@ -1,12 +1,14 @@
 ---
 source: src/lib.rs
+assertion_line: 407
 expression: "parse(\"hostname[0-3]-eth0.iml.com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname0-eth0.iml.com",
         "hostname1-eth0.iml.com",
         "hostname2-eth0.iml.com",
         "hostname3-eth0.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Single item with three ranges separated by character.snap
+++ b/src/snapshots/hostlist_parser__tests__Single item with three ranges separated by character.snap
@@ -1,9 +1,11 @@
 ---
 source: src/lib.rs
+assertion_line: 412
 expression: "parse(\"hostname[1,2]-[3-4]-[5,6].iml.com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname1-3-5.iml.com",
         "hostname1-3-6.iml.com",
         "hostname1-4-5.iml.com",
@@ -12,5 +14,5 @@ Ok(
         "hostname2-3-6.iml.com",
         "hostname2-4-5.iml.com",
         "hostname2-4-6.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Single item with two ranges and no separation between the ranges.snap
+++ b/src/snapshots/hostlist_parser__tests__Single item with two ranges and no separation between the ranges.snap
@@ -1,12 +1,14 @@
 ---
 source: src/lib.rs
+assertion_line: 417
 expression: "parse(\"hostname[1,2][3,4].iml.com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname13.iml.com",
         "hostname14.iml.com",
         "hostname23.iml.com",
         "hostname24.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__Single range per hostname with dup.snap
+++ b/src/snapshots/hostlist_parser__tests__Single range per hostname with dup.snap
@@ -1,20 +1,22 @@
 ---
 source: src/lib.rs
+assertion_line: 380
 expression: "parse(\"hostname[2,6,7].iml.com,hostname[10,11-12,2-4,5].iml.com, hostname[15-17].iml.com\")"
+
 ---
 Ok(
-    {
+    [
+        "hostname2.iml.com",
+        "hostname6.iml.com",
+        "hostname7.iml.com",
         "hostname10.iml.com",
         "hostname11.iml.com",
         "hostname12.iml.com",
-        "hostname15.iml.com",
-        "hostname16.iml.com",
-        "hostname17.iml.com",
-        "hostname2.iml.com",
         "hostname3.iml.com",
         "hostname4.iml.com",
         "hostname5.iml.com",
-        "hostname6.iml.com",
-        "hostname7.iml.com",
-    },
+        "hostname15.iml.com",
+        "hostname16.iml.com",
+        "hostname17.iml.com",
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__long range with prefix.snap
+++ b/src/snapshots/hostlist_parser__tests__long range with prefix.snap
@@ -1,9 +1,11 @@
 ---
 source: src/lib.rs
+assertion_line: 361
 expression: "parse(\"hostname[001-999]\")"
+
 ---
 Ok(
-    {
+    [
         "hostname001",
         "hostname002",
         "hostname003",
@@ -1003,5 +1005,5 @@ Ok(
         "hostname997",
         "hostname998",
         "hostname999",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__multiple items combined into regular and reverse order.snap
+++ b/src/snapshots/hostlist_parser__tests__multiple items combined into regular and reverse order.snap
@@ -1,16 +1,18 @@
 ---
 source: src/lib.rs
+assertion_line: 363
 expression: "parse(\"hostname[7-5], hostname[8,9], hostname[3,2,1]\")"
+
 ---
 Ok(
-    {
-        "hostname1",
-        "hostname2",
-        "hostname3",
-        "hostname5",
-        "hostname6",
+    [
         "hostname7",
+        "hostname6",
+        "hostname5",
         "hostname8",
         "hostname9",
-    },
+        "hostname3",
+        "hostname2",
+        "hostname1",
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__parse-2.snap
+++ b/src/snapshots/hostlist_parser__tests__parse-2.snap
@@ -1,9 +1,11 @@
 ---
 source: src/lib.rs
+assertion_line: 316
 expression: "parse(\"oss1.local\")"
+
 ---
 Ok(
-    {
+    [
         "oss1.local",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__parse-3.snap
+++ b/src/snapshots/hostlist_parser__tests__parse-3.snap
@@ -1,14 +1,16 @@
 ---
 source: src/lib.rs
+assertion_line: 318
 expression: "parse(\"hostname[10,11-12,002-003,5].iml.com\")"
+
 ---
 Ok(
-    {
-        "hostname002.iml.com",
-        "hostname003.iml.com",
+    [
         "hostname10.iml.com",
         "hostname11.iml.com",
         "hostname12.iml.com",
+        "hostname002.iml.com",
+        "hostname003.iml.com",
         "hostname5.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__parse-4.snap
+++ b/src/snapshots/hostlist_parser__tests__parse-4.snap
@@ -1,19 +1,21 @@
 ---
 source: src/lib.rs
+assertion_line: 327
 expression: "parse(\"hostname[2,6,7].iml.com,hostname[10,11-12,2-3,5].iml.com,hostname[15-17].iml.com\")"
+
 ---
 Ok(
-    {
+    [
+        "hostname2.iml.com",
+        "hostname6.iml.com",
+        "hostname7.iml.com",
         "hostname10.iml.com",
         "hostname11.iml.com",
         "hostname12.iml.com",
+        "hostname3.iml.com",
+        "hostname5.iml.com",
         "hostname15.iml.com",
         "hostname16.iml.com",
         "hostname17.iml.com",
-        "hostname2.iml.com",
-        "hostname3.iml.com",
-        "hostname5.iml.com",
-        "hostname6.iml.com",
-        "hostname7.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__parse-5.snap
+++ b/src/snapshots/hostlist_parser__tests__parse-5.snap
@@ -1,19 +1,21 @@
 ---
 source: src/lib.rs
+assertion_line: 331
 expression: "parse(\"hostname[2,6,7].iml.com,  hostname[10,11-12,2-3,5].iml.com, hostname[15-17].iml.com\")"
+
 ---
 Ok(
-    {
+    [
+        "hostname2.iml.com",
+        "hostname6.iml.com",
+        "hostname7.iml.com",
         "hostname10.iml.com",
         "hostname11.iml.com",
         "hostname12.iml.com",
+        "hostname3.iml.com",
+        "hostname5.iml.com",
         "hostname15.iml.com",
         "hostname16.iml.com",
         "hostname17.iml.com",
-        "hostname2.iml.com",
-        "hostname3.iml.com",
-        "hostname5.iml.com",
-        "hostname6.iml.com",
-        "hostname7.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__parse.snap
+++ b/src/snapshots/hostlist_parser__tests__parse.snap
@@ -1,10 +1,12 @@
 ---
 source: src/lib.rs
+assertion_line: 314
 expression: "parse(\"oss[1,2].local\")"
+
 ---
 Ok(
-    {
+    [
         "oss1.local",
         "oss2.local",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__range_digits-4.snap
+++ b/src/snapshots/hostlist_parser__tests__range_digits-4.snap
@@ -1,10 +1,12 @@
 ---
 source: src/lib.rs
+assertion_line: 281
 expression: "range_digits().easy_parse(\"100-0\")"
+
 ---
 Ok(
     (
-        Range(
+        RangeReversed(
             0,
             0,
             100,

--- a/src/snapshots/hostlist_parser__tests__single item in reverse order.snap
+++ b/src/snapshots/hostlist_parser__tests__single item in reverse order.snap
@@ -1,11 +1,13 @@
 ---
 source: src/lib.rs
+assertion_line: 361
 expression: "parse(\"hostname[7-5]\")"
+
 ---
 Ok(
-    {
-        "hostname5",
-        "hostname6",
+    [
         "hostname7",
-    },
+        "hostname6",
+        "hostname5",
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__single item with double digit prefixed range.snap
+++ b/src/snapshots/hostlist_parser__tests__single item with double digit prefixed range.snap
@@ -1,11 +1,13 @@
 ---
 source: src/lib.rs
+assertion_line: 349
 expression: "parse(\"hostname[009-011]\")"
+
 ---
 Ok(
-    {
+    [
         "hostname009",
         "hostname010",
         "hostname011",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__single item with range containing mixture of comma and dash.snap
+++ b/src/snapshots/hostlist_parser__tests__single item with range containing mixture of comma and dash.snap
@@ -1,12 +1,14 @@
 ---
 source: src/lib.rs
+assertion_line: 368
 expression: "parse(\"hostname[7,9-11].iml.com\")"
+
 ---
 Ok(
-    {
-        "hostname10.iml.com",
-        "hostname11.iml.com",
+    [
         "hostname7.iml.com",
         "hostname9.iml.com",
-    },
+        "hostname10.iml.com",
+        "hostname11.iml.com",
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__single item with single digit prefixed range.snap
+++ b/src/snapshots/hostlist_parser__tests__single item with single digit prefixed range.snap
@@ -1,11 +1,13 @@
 ---
 source: src/lib.rs
+assertion_line: 345
 expression: "parse(\"hostname[09-11]\")"
+
 ---
 Ok(
-    {
+    [
         "hostname09",
         "hostname10",
         "hostname11",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__single item with single range and nothing after the range.snap
+++ b/src/snapshots/hostlist_parser__tests__single item with single range and nothing after the range.snap
@@ -1,9 +1,11 @@
 ---
 source: src/lib.rs
+assertion_line: 340
 expression: "parse(\"hostname[6]\")"
+
 ---
 Ok(
-    {
+    [
         "hostname6",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__single item with single range.snap
+++ b/src/snapshots/hostlist_parser__tests__single item with single range.snap
@@ -1,9 +1,11 @@
 ---
 source: src/lib.rs
+assertion_line: 335
 expression: "parse(\"hostname[6].iml.com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname6.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__single item with two ranges.snap
+++ b/src/snapshots/hostlist_parser__tests__single item with two ranges.snap
@@ -1,14 +1,16 @@
 ---
 source: src/lib.rs
+assertion_line: 363
 expression: "parse(\"hostname[6,7]-[9-11].iml.com\")"
+
 ---
 Ok(
-    {
+    [
+        "hostname6-9.iml.com",
         "hostname6-10.iml.com",
         "hostname6-11.iml.com",
-        "hostname6-9.iml.com",
+        "hostname7-9.iml.com",
         "hostname7-10.iml.com",
         "hostname7-11.iml.com",
-        "hostname7-9.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__single item without ranges.snap
+++ b/src/snapshots/hostlist_parser__tests__single item without ranges.snap
@@ -1,9 +1,11 @@
 ---
 source: src/lib.rs
+assertion_line: 328
 expression: "parse(\"hostname1.iml.com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname1.iml.com",
-    },
+    ],
 )

--- a/src/snapshots/hostlist_parser__tests__two items without ranges.snap
+++ b/src/snapshots/hostlist_parser__tests__two items without ranges.snap
@@ -1,10 +1,12 @@
 ---
 source: src/lib.rs
+assertion_line: 330
 expression: "parse(\"hostname1.iml.com, hostname2.iml.com\")"
+
 ---
 Ok(
-    {
+    [
         "hostname1.iml.com",
         "hostname2.iml.com",
-    },
+    ],
 )

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -1,19 +1,24 @@
-// Copyright (c) 2019 DDN. All rights reserved.
+// Copyright (c) 2022 DDN. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
 #[derive(Debug, Clone)]
-pub enum RangeOutput {
+pub(crate) enum RangeOutput {
     Range(usize, u64, u64),
+    RangeReversed(usize, u64, u64),
     Disjoint(Vec<u64>),
 }
 
 impl RangeOutput {
-    pub fn iter(&self) -> RangeOutputIter {
+    pub(crate) fn iter(&self) -> RangeOutputIter {
         match self {
             RangeOutput::Range(prefix, start, end) => RangeOutputIter {
                 prefix: *prefix,
                 iterator: Box::new(*start..=*end),
+            },
+            RangeOutput::RangeReversed(prefix, end, start) => RangeOutputIter {
+                prefix: *prefix,
+                iterator: Box::new((*end..=*start).rev()),
             },
             RangeOutput::Disjoint(xs) => RangeOutputIter {
                 prefix: 0,
@@ -23,7 +28,7 @@ impl RangeOutput {
     }
 }
 
-pub struct RangeOutputIter {
+pub(crate) struct RangeOutputIter {
     prefix: usize,
     iterator: Box<dyn Iterator<Item = u64>>,
 }
@@ -38,18 +43,18 @@ impl Iterator for RangeOutputIter {
     }
 }
 
-pub fn format_num_prefix(num: u64, prefix: usize) -> String {
+pub(crate) fn format_num_prefix(num: u64, prefix: usize) -> String {
     format!("{:0>width$}", num, width = prefix + 1)
 }
 
 #[derive(Debug, Clone)]
-pub enum Part {
+pub(crate) enum Part {
     String(String),
     Range(Vec<RangeOutput>),
 }
 
 impl Part {
-    pub fn get_ranges(&self) -> Option<&Vec<RangeOutput>> {
+    pub(crate) fn get_ranges(&self) -> Option<&Vec<RangeOutput>> {
         match self {
             Part::Range(xs) => Some(xs),
             _ => None,
@@ -57,7 +62,7 @@ impl Part {
     }
 }
 
-pub fn flatten_ranges(xs: &[RangeOutput]) -> Vec<String> {
+pub(crate) fn flatten_ranges(xs: &[RangeOutput]) -> Vec<String> {
     xs.iter().map(|x| x.iter()).flatten().collect()
 }
 


### PR DESCRIPTION
There may be cases where order is important when getting a hostlist result.
Switch from `BTreeSet` which does not respect parse order to a deduped `Vec` which does.

In addition, properly handle descending ranges.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>